### PR TITLE
Don't try to derefence disk.usage pointer in error case

### DIFF
--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -30,7 +30,11 @@ func GetDiskUsageSingle(ctx context.Context, timeout time.Duration, fs *Filesyst
 	go func() {
 		tmp := tmpFileSystemWrapper{}
 		usageStats, err := disk.Usage(fs.PartStats.Mountpoint)
-		tmp.usage = *usageStats
+
+		if err == nil {
+			tmp.usage = *usageStats
+		}
+
 		tmp.err = err
 
 		resChan <- tmp


### PR DESCRIPTION
This fixes an error when a filesystem is mounted below a directory for which the user, which executes the plugin, does not have read permissions.
In that scenario, the code tried to dereference a pointer without checking whether `diskUsage` returned an error.

In the case of an error, this pointer is `nil` and was dereferenced, which caused a panic.

This commit checks whether an error occured and does no try to access the pointer, if there is an error.