### PR TITLE
Enhanced error message on missing psi files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,12 @@ issues:
         - gocognit
         - maintidx
         - gocyclo
+    - path: 'cmd/psi.go'
+      linters:
+        - funlen
+        - gocognit
+        - gocyclo
+        - maintidx
     - path: 'internal/sensors/sensors.go'
       linters:
         - funlen

--- a/cmd/psi.go
+++ b/cmd/psi.go
@@ -234,7 +234,6 @@ func init() {
 	psiFs.BoolVar(&config.IncludeIO, "include-io", false, "Include IO values explicitly (by default all are included)")
 }
 
-//nolint:funlen,gocognit,gocyclo
 func checkPsiCPUPressure(config *psiConfig) result.PartialResult {
 	var cpuCheck result.PartialResult
 	_ = cpuCheck.SetDefaultState(check.OK)
@@ -369,7 +368,6 @@ func checkPsiCPUPressure(config *psiConfig) result.PartialResult {
 	return cpuCheck
 }
 
-//nolint:funlen,gocognit,gocyclo
 func checkPsiIoPressure(config *psiConfig) result.PartialResult {
 	var ioCheck result.PartialResult
 	_ = ioCheck.SetDefaultState(check.OK)
@@ -498,7 +496,6 @@ func checkPsiIoPressure(config *psiConfig) result.PartialResult {
 	return ioCheck
 }
 
-//nolint:funlen,gocognit,gocyclo
 func checkPsiMemoryPressure(config *psiConfig) result.PartialResult {
 	var memoryCheck result.PartialResult
 	_ = memoryCheck.SetDefaultState(check.OK)

--- a/cmd/psi.go
+++ b/cmd/psi.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/NETWAYS/check_system_basics/internal/common/thresholds"
 	"github.com/NETWAYS/check_system_basics/internal/psi"
@@ -234,12 +236,21 @@ func init() {
 
 //nolint:funlen,gocognit,gocyclo
 func checkPsiCPUPressure(config *psiConfig) result.PartialResult {
+	var cpuCheck result.PartialResult
+	_ = cpuCheck.SetDefaultState(check.OK)
+
 	psiCPU, err := psi.ReadCPUPressure()
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			_ = cpuCheck.SetState(check.Unknown)
+			cpuCheck.Output = "CPU pressure file not found. Perhaps the PSI interface is not active on this system? It might be necessary to change the kernel config"
+
+			return cpuCheck
+		}
+
 		check.ExitError(err)
 	}
 
-	var cpuCheck result.PartialResult
 	cpuCheck.Perfdata = *psiCPU.Perfdata()
 	_ = cpuCheck.SetState(check.OK)
 
@@ -360,13 +371,21 @@ func checkPsiCPUPressure(config *psiConfig) result.PartialResult {
 
 //nolint:funlen,gocognit
 func checkPsiIoPressure(config *psiConfig) result.PartialResult {
+	var ioCheck result.PartialResult
+	_ = ioCheck.SetDefaultState(check.OK)
+
 	psiIo, err := psi.ReadIoPressure()
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			_ = ioCheck.SetState(check.Unknown)
+			ioCheck.Output = "IO pressure file not found. Perhaps the PSI interface is not active on this system? It might be necessary to change the kernel config"
+
+			return ioCheck
+		}
+
 		check.ExitError(err)
 	}
 
-	var ioCheck result.PartialResult
-	_ = ioCheck.SetState(check.OK)
 	ioCheck.Perfdata = *psiIo.Perfdata()
 
 	//nolint:nestif
@@ -481,13 +500,21 @@ func checkPsiIoPressure(config *psiConfig) result.PartialResult {
 
 //nolint:funlen,gocognit
 func checkPsiMemoryPressure(config *psiConfig) result.PartialResult {
+	var memoryCheck result.PartialResult
+	_ = memoryCheck.SetDefaultState(check.OK)
+
 	psiMemory, err := psi.ReadMemoryPressure()
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			_ = memoryCheck.SetState(check.Unknown)
+			memoryCheck.Output = "IO pressure file not found. Perhaps the PSI interface is not active on this system? It might be necessary to change the kernel config"
+
+			return memoryCheck
+		}
+
 		check.ExitError(err)
 	}
 
-	var memoryCheck result.PartialResult
-	_ = memoryCheck.SetState(check.OK)
 	memoryCheck.Perfdata = *psiMemory.Perfdata()
 
 	//nolint:nestif

--- a/cmd/psi.go
+++ b/cmd/psi.go
@@ -369,7 +369,7 @@ func checkPsiCPUPressure(config *psiConfig) result.PartialResult {
 	return cpuCheck
 }
 
-//nolint:funlen,gocognit
+//nolint:funlen,gocognit,gocyclo
 func checkPsiIoPressure(config *psiConfig) result.PartialResult {
 	var ioCheck result.PartialResult
 	_ = ioCheck.SetDefaultState(check.OK)
@@ -498,7 +498,7 @@ func checkPsiIoPressure(config *psiConfig) result.PartialResult {
 	return ioCheck
 }
 
-//nolint:funlen,gocognit
+//nolint:funlen,gocognit,gocyclo
 func checkPsiMemoryPressure(config *psiConfig) result.PartialResult {
 	var memoryCheck result.PartialResult
 	_ = memoryCheck.SetDefaultState(check.OK)

--- a/internal/netdev/netdev.go
+++ b/internal/netdev/netdev.go
@@ -2,6 +2,7 @@ package netdev
 
 import (
 	"os"
+	"path"
 	"strconv"
 	"strings"
 
@@ -157,7 +158,7 @@ func listInterfaces() ([]string, error) {
 	result := make([]string, 0, len(devices))
 
 	for idx := range devices {
-		fileInfo, err := os.Stat(netDevicePath + devices[idx])
+		fileInfo, err := os.Stat(path.Join(netDevicePath, devices[idx]))
 		if err != nil {
 			// Could not stat file there, not sure if this can be handled usefully. Just die for now.
 			return []string{}, err
@@ -180,9 +181,9 @@ func listInterfaces() ([]string, error) {
 // @result = 2 => Interface is down
 // @result = 3 => Interface is unknown or state of the interface is unknown for some reason
 func getInterfaceState(data *IfaceData) error {
-	basePath := netDevicePath + data.Name
+	basePath := path.Join(netDevicePath, data.Name)
 
-	bytes, err := os.ReadFile(basePath + "/operstate")
+	bytes, err := os.ReadFile(path.Join(basePath, "operstate"))
 	if err != nil {
 		return err
 	}
@@ -209,12 +210,12 @@ func getInterfaceState(data *IfaceData) error {
 // Get interfaces statistics
 // @result: ifaceStats, err
 func getInfacesStatistics(data *IfaceData) error {
-	basePath := netDevicePath + data.Name + "/statistics"
+	basePath := path.Join(netDevicePath, data.Name, "statistics")
 
 	var val uint64
 
 	for idx, stat := range GetIfaceStatNames() {
-		numberBytes, err := os.ReadFile(basePath + "/" + stat)
+		numberBytes, err := os.ReadFile(path.Join(basePath, stat))
 
 		if err != nil {
 			return err

--- a/internal/netdev/netdev.go
+++ b/internal/netdev/netdev.go
@@ -150,7 +150,20 @@ func listInterfaces() ([]string, error) {
 		return []string{}, err
 	}
 
-	return devices, nil
+	result := make([]string, 0, len(devices))
+	for idx := range devices {
+		fileInfo, err := os.Stat("/sys/class/net/" + devices[idx])
+		if err != nil {
+			// Could not stat file there, not sure if this can be handled usefully. Just die for now.
+			return []string{}, err
+		}
+
+		if fileInfo.Mode().IsDir() {
+			result = append(result, devices[idx])
+		}
+	}
+
+	return result, nil
 }
 
 // getInterfaceState receives the name of an interfaces and returns

--- a/internal/netdev/netdev.go
+++ b/internal/netdev/netdev.go
@@ -155,6 +155,7 @@ func listInterfaces() ([]string, error) {
 	}
 
 	result := make([]string, 0, len(devices))
+
 	for idx := range devices {
 		fileInfo, err := os.Stat(netDevicePath + devices[idx])
 		if err != nil {

--- a/internal/netdev/netdev.go
+++ b/internal/netdev/netdev.go
@@ -18,6 +18,10 @@ const (
 	Unknown        = 4
 )
 
+const (
+	netDevicePath = "/sys/class/net"
+)
+
 func TranslateIfaceState(state uint) string {
 	switch state {
 	case Up:
@@ -140,7 +144,7 @@ func GetAllInterfaces() ([]IfaceData, error) {
 }
 
 func listInterfaces() ([]string, error) {
-	file, err := os.Open("/sys/class/net")
+	file, err := os.Open(netDevicePath)
 	if err != nil {
 		return []string{}, err
 	}
@@ -152,7 +156,7 @@ func listInterfaces() ([]string, error) {
 
 	result := make([]string, 0, len(devices))
 	for idx := range devices {
-		fileInfo, err := os.Stat("/sys/class/net/" + devices[idx])
+		fileInfo, err := os.Stat(netDevicePath + devices[idx])
 		if err != nil {
 			// Could not stat file there, not sure if this can be handled usefully. Just die for now.
 			return []string{}, err
@@ -172,7 +176,7 @@ func listInterfaces() ([]string, error) {
 // @result = 2 => Interface is down
 // @result = 3 => Interface is unknown or state of the interface is unknown for some reason
 func getInterfaceState(data *IfaceData) error {
-	basePath := "/sys/class/net/" + data.Name
+	basePath := netDevicePath + data.Name
 
 	bytes, err := os.ReadFile(basePath + "/operstate")
 	if err != nil {
@@ -201,7 +205,7 @@ func getInterfaceState(data *IfaceData) error {
 // Get interfaces statistics
 // @result: ifaceStats, err
 func getInfacesStatistics(data *IfaceData) error {
-	basePath := "/sys/class/net/" + data.Name + "/statistics"
+	basePath := netDevicePath + data.Name + "/statistics"
 
 	var val uint64
 

--- a/internal/netdev/netdev.go
+++ b/internal/netdev/netdev.go
@@ -163,6 +163,9 @@ func listInterfaces() ([]string, error) {
 			return []string{}, err
 		}
 
+		// Filter here, to get only entries which end in a directory (the entries itself are mostly symlinks)
+		// Despite of what man 5 sysfs says, not all the files represent network interfaces, but might also
+		// be normal files (at least a "bonding_masters" file was found on a system with bonded interfaces)
 		if fileInfo.Mode().IsDir() {
 			result = append(result, devices[idx])
 		}


### PR DESCRIPTION
On some distributions the PSI interface is disabled by default. In this case the psi mode is not usable.

The resulting error message was not that helpful, this commit tries to remedy that by enhancing the error message and be a bit more elaborate about the specific cause.