### PR TITLE
small fix for help output on the filesystem check

### DIFF
--- a/cmd/filesystem.go
+++ b/cmd/filesystem.go
@@ -593,7 +593,7 @@ func init() {
 		{
 			Th:          &FsConfig.CriticalAbsolutThreshold.Inodes.Free,
 			FlagString:  "warningAbsolutFreeInodes",
-			Description: "Absolute critical threshold for number of free inodes",
+			Description: "Absolute warning threshold for number of free inodes",
 		},
 		{
 			Th:          &FsConfig.CriticalAbsolutThreshold.Inodes.Used,


### PR DESCRIPTION
As there seems to be a small copy paste issue on the filesystem checks help output i fixed it:
Before:
```
--warningAbsolutFreeInodes Range_Expression      Absolute critical threshold for number of free inodes
--criticalAbsolutUsedInodes Range_Expression     Absolute critical threshold for number of used inodes
```
After:
```
--warningAbsolutFreeInodes Range_Expression      Absolute warning threshold for number of free inodes
--criticalAbsolutUsedInodes Range_Expression     Absolute critical threshold for number of used inodes
```