### PR TITLE
Fix percentage performance data for used memory

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -214,7 +214,7 @@ func computeMemResults(config *memory.MemConfig, memStats *memory.Mem) result.Pa
 
 	MemUsedPercentage := float64(memStats.VirtMem.Used) / (float64(memStats.VirtMem.Total) / 100)
 	pdMemUsedPercentage := perfdata.Perfdata{
-		Label: "free_memory_percentage",
+		Label: "used_memory_percentage",
 		Value: MemUsedPercentage,
 		Uom:   "%",
 	}


### PR DESCRIPTION
This changes the label of an optional performance data value which to the correct string, which is an error resulting from copy and pasting another section.