### PR TITLE
Refactor version logic

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,3 +24,5 @@ builds:
       - amd64
       - 386
       - riscv64
+    ldflags:
+      - -X github.com/NETWAYS/check_system_basics/cmd.version={{.Version}}

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(GIT_COMMIT), $(GIT_LAST_TAG_COMMIT))
 	VERSION = $(shell git tag -l --contains $(GIT_COMMIT))
 endif
 
-GO_LINKERFLAGS := "-X main.version=$(VERSION)"
+GO_LINKERFLAGS := "-X github.com/NETWAYS/check_system_basics/cmd.version=$(VERSION)"
 
 GO_LINKEROPTS := -ldflags $(GO_LINKERFLAGS)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,20 +12,22 @@ import (
 var Timeout = 30
 var debug = false
 
+var (
+	version string
+)
+
 var rootCmd = &cobra.Command{
-	Use:   "check_system_basics",
-	Short: "Icinga check plugin to check various Linux metrics",
+	Use:     "check_system_basics",
+	Short:   "Icinga check plugin to check various Linux metrics",
+	Version: version,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		go check.HandleTimeout(Timeout)
 	},
 	Run: RunFunction,
 }
 
-func Execute(version string) {
+func Execute() {
 	defer check.CatchPanic()
-
-	rootCmd.Version = version
-	rootCmd.VersionTemplate()
 
 	if err := rootCmd.Execute(); err != nil {
 		check.ExitError(err)
@@ -52,8 +54,6 @@ func init() {
 
 	flagSet := rootCmd.Flags()
 	flagSet.Bool("dump-icinga2-config", false, "Dump icinga2 config for this plugin")
-
-	flagSet.Bool("version", false, "Display version and other information about this program")
 }
 
 func RunFunction(cmd *cobra.Command, args []string) {
@@ -66,16 +66,6 @@ func RunFunction(cmd *cobra.Command, args []string) {
 
 	if dumpConfig {
 		ConfigDump(cmd, cmd.CommandPath())
-		os.Exit(check.OK)
-	}
-
-	showVersion, err := flagSet.GetBool("version")
-	if err != nil {
-		check.ExitError(err)
-	}
-
-	if showVersion {
-		fmt.Println(cmd.Version)
 		os.Exit(check.OK)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,32 +1,9 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/NETWAYS/check_system_basics/cmd"
 )
 
-var (
-	version string
-	commit  = ""
-	date    = ""
-)
-
 func main() {
-	cmd.Execute(buildVersion())
-}
-
-//goland:noinspection GoBoolExpressions
-func buildVersion() string {
-	result := version
-
-	if commit != "" {
-		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
-	}
-
-	if date != "" {
-		result = fmt.Sprintf("%s\ndate: %s", result, date)
-	}
-
-	return result
+	cmd.Execute()
 }


### PR DESCRIPTION
Previously the version was generated in the main function at runtime.

This patch use the cobra cmd native functionality to include it, which reduces the logic in this program.
The version is not generated in the Makefile and linked into the program at compile time.