### PR TITLE
Add missing indices for totals

### DIFF
--- a/internal/psi/psi.go
+++ b/internal/psi/psi.go
@@ -13,27 +13,33 @@ const (
 	CPUSomeAvg10 uint = iota
 	CPUSomeAvg60
 	CPUSomeAvg300
+	CPUSomeTotal
 	CPUFullAvg10
 	CPUFullAvg60
 	CPUFullAvg300
+	CPUFullTotal
 )
 
 const (
 	IoSomeAvg10 uint = iota
 	IoSomeAvg60
 	IoSomeAvg300
+	IoSomeTotal
 	IoFullAvg10
 	IoFullAvg60
 	IoFullAvg300
+	IoFullTotal
 )
 
 const (
 	MemorySomeAvg10 uint = iota
 	MemorySomeAvg60
 	MemorySomeAvg300
+	MemorySomeTotal
 	MemoryFullAvg10
 	MemoryFullAvg60
 	MemoryFullAvg300
+	MemoryFullTotal
 )
 
 type PressureValue struct {


### PR DESCRIPTION
The indices for perfdata values with the total measurements (e.g. memory full total) were previously missing.
Since these elements are arranged in arrays the addressing was wrong and thresholds were assigned to the wrong values. This commit adds the missing indices